### PR TITLE
fix: todo-issue-reopener permissions

### DIFF
--- a/.github/workflows/schedule.issue-reopener.yml
+++ b/.github/workflows/schedule.issue-reopener.yml
@@ -25,6 +25,8 @@ jobs:
   issue-reopener:
     runs-on: ubuntu-latest
     permissions:
+      # NOTE: contents: read is necessary for private repositories.
+      contents: read
       issues: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Add `contents: read` permissions for private repositories.