### PR TITLE
fix: Add Makefile to license-headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ license-headers: ## Update license headers.
 				'*.py' '**/*.py' \
 				'*.yaml' '**/*.yaml' \
 				'*.yml' '**/*.yml' \
+				'Makefile' \
 		); \
 		name=$$(git config user.name); \
 		if [ "$${name}" == "" ]; then \


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Add `Makefile` to files in `license-headers` makefile target.

**Related Issues:**

Fixes #92 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
