### PR TITLE
docs: remove --log from sync instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ git remote add repo-template git@github.com:ianlewis/repo-template.git
 git fetch repo-template main
 
 # Create a new squash merge commit.
-git merge --no-edit --signoff --squash --allow-unrelated-histories --log repo-template/main
+git merge --no-edit --signoff --squash --allow-unrelated-histories repo-template/main
 ```
 
 ## Language-specific templates


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Remove `--log` option from the instructions on how to sync with the template repo.

**Related Issues:**

Fixes #91

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
