### PR TITLE
fix: Don't upload SARIF for private repos

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -128,6 +128,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
+        # NOTE: Uploading SARIF requires GitHub Enterprise and GitHub Advanced Security license for private repositories.
+        if: github.event.repository.private == false
         uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           sarif_file: zizmor.sarif.json

--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,7 @@ actionlint: ## Runs the actionlint linter.
 .PHONY: zizmor
 zizmor: .venv/.installed ## Runs the zizmor linter.
 	@# NOTE: On GitHub actions this outputs SARIF format to zizmor.sarif.json
-	@#       rather than outputting errors to the terminal. This is so that
-	@#       security issues can be uploaded privately rather than being made
-	@#       public.
+	@#       in addition to outputting errors to the terminal.
 	@set -euo pipefail;\
 		extraargs=""; \
 		files=$$( \
@@ -149,10 +147,9 @@ zizmor: .venv/.installed ## Runs the zizmor linter.
 				'.github/workflows/*.yaml' \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
-			.venv/bin/zizmor --quiet --pedantic --format sarif $${files} > zizmor.sarif.json; \
-		else \
-			.venv/bin/zizmor --quiet --pedantic --format plain $${files}; \
-		fi
+			.venv/bin/zizmor --quiet --pedantic --format sarif $${files} > zizmor.sarif.json || true; \
+		fi; \
+		.venv/bin/zizmor --quiet --pedantic --format plain $${files}
 
 .PHONY: markdownlint
 markdownlint: node_modules/.installed ## Runs the markdownlint linter.


### PR DESCRIPTION
**Description:**

Uploading SARIF requires GitHub Enterprise and GitHub Advanced Security license for private repositories. Don't upload SARIF in the case of private repositories.

**Related Issues:**

Fixes #123 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
