### PR TITLE
fix: Filter out submodule paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ license-headers: ## Update license headers.
 				'*.yaml' \
 				'*.yml' \
 				'Makefile' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		name=$$(git config user.name); \
 		if [ "$${name}" == "" ]; then \
@@ -101,6 +102,7 @@ md-format: node_modules/.installed ## Format Markdown files.
 		files=$$( \
 			git ls-files --deduplicate \
 				'*.md' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		npx prettier --write --no-error-on-unmatched-pattern $${files}
 
@@ -128,6 +130,7 @@ actionlint: ## Runs the actionlint linter.
 			git ls-files --deduplicate \
 				'.github/workflows/*.yml' \
 				'.github/workflows/*.yaml' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			actionlint -format '{{range $$err := .}}::error file={{$$err.Filepath}},line={{$$err.Line}},col={{$$err.Column}}::{{$$err.Message}}%0A```%0A{{replace $$err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' -ignore 'SC2016:' $${files}; \
@@ -144,6 +147,7 @@ zizmor: .venv/.installed ## Runs the zizmor linter.
 			git ls-files --deduplicate \
 				'.github/workflows/*.yml' \
 				'.github/workflows/*.yaml' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			.venv/bin/zizmor --quiet --pedantic --format sarif $${files} > zizmor.sarif.json || true; \
@@ -161,6 +165,7 @@ markdownlint: node_modules/.installed ## Runs the markdownlint linter.
 				'*.md' \
 				':!:.github/pull_request_template.md' \
 				':!:.github/ISSUE_TEMPLATE/*.md' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			exit_code=0; \
@@ -182,6 +187,7 @@ markdownlint: node_modules/.installed ## Runs the markdownlint linter.
 			git ls-files --deduplicate \
 				'.github/pull_request_template.md' \
 				'.github/ISSUE_TEMPLATE/*.md' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			exit_code=0; \
@@ -207,6 +213,7 @@ textlint: node_modules/.installed ## Runs the textlint linter.
 			git ls-files --deduplicate \
 				'*.md' \
 				'*.txt' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			exit_code=0; \
@@ -233,6 +240,7 @@ yamllint: .venv/.installed ## Runs the yamllint linter.
 			git ls-files --deduplicate \
 				'*.yml' \
 				'*.yaml' \
+				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			extraargs="-f github"; \


### PR DESCRIPTION
**Description:**

Some directories that contain git submodules will match patterns given to `git ls-files` because they contain git tree entries even though they are directories on disk. This PR filters out submodule paths from most Makefile commands.

**Related Issues:**

Fixes #145

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
