### PR TITLE
fix: format md files with tabstop=4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,18 @@ json-format: node_modules/.installed ## Format JSON files.
 
 .PHONY: md-format
 md-format: node_modules/.installed ## Format Markdown files.
+	@#NOTE: tab-width of 4 is recommended for Markdown files. 
 	@set -euo pipefail; \
 		files=$$( \
 			git ls-files --deduplicate \
 				'*.md' \
 				| while IFS='' read -r f; do [ -f "$${f}" ] && echo "$${f}"; done \
 		); \
-		npx prettier --write --no-error-on-unmatched-pattern $${files}
+		npx prettier \
+			--tab-width 4 \
+			--write \
+			--no-error-on-unmatched-pattern \
+			$${files}
 
 .PHONY: yaml-format
 yaml-format: node_modules/.installed ## Format YAML files.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ The following tools should be added to the required code scanning results.
 1. [ ] **CodeQL analysis:**
        Make sure "GitHub Actions (Public Preview)" is enabled in languages.
 2. [ ] **Protection rules:**
-   - [ ] **Security alert severity level:** Errors and warnings
-   - [ ] **Standard alert severity level:** Errors and warnings
+    - [ ] **Security alert severity level:** Errors and warnings
+    - [ ] **Standard alert severity level:** Errors and warnings
 3. [ ] **Secret protection:**
        Get alerts when secrets are detected in the repo.
 4. [ ] **Push protection:**

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -84,6 +84,11 @@
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.333.1/registry.yaml",
       "checksum": "9DBB73AF6D587E7696230A00BF9AD1A4D1B62512D5C179D55A5B471F332FF52E",
       "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.335.0/registry.yaml",
+      "checksum": "227996226562CC18DD591C7C6E4C66EC7B83B1887AD43C94C3F7E641C7883CF1E86F3772102CF28DFA8DA81A9AB4E67030FF5023E718C30AEA133F16145DAEFF",
+      "algorithm": "sha512"
     }
   ]
 }


### PR DESCRIPTION
**Description:**

Format markdown files with tab stop of 4.

**Related Issues:**

Fixes #179 

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
