### PR TITLE
fix: Makefile doesn't output color to non-terminals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,26 @@ help: ## Print all Makefile targets (this message).
 	@echo "$(REPO_NAME) Makefile"
 	@echo "Usage: make [COMMAND]"
 	@echo ""
-	@grep --no-filename -E '^([/a-z.A-Z0-9_%-]+:.*?|)##' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = "(:.*?|)## ?"}; { \
-			if (length($$1) > 0) { \
-				printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2; \
-			} else { \
-				if (length($$2) > 0) { \
-					printf "%s\n", $$2; \
-				} \
-			} \
-		}'
+	@set -euo pipefail; \
+		normal=""; \
+		cyan=""; \
+		if [ -t 1 ]; then \
+			normal=$$(tput sgr0); \
+			cyan=$$(tput setaf 6); \
+		fi; \
+		grep --no-filename -E '^([/a-z.A-Z0-9_%-]+:.*?|)##' $(MAKEFILE_LIST) | \
+			awk \
+				--assign=normal="$${normal}" \
+				--assign=cyan="$${cyan}" \
+				'BEGIN {FS = "(:.*?|)## ?"}; { \
+					if (length($$1) > 0) { \
+						printf("  " cyan "%-25s" normal " %s\n", $$1, $$2); \
+					} else { \
+						if (length($$2) > 0) { \
+							printf("%s\n", $$2); \
+						} \
+					} \
+				}'
 
 package-lock.json: package.json
 	@npm install

--- a/README.md
+++ b/README.md
@@ -94,22 +94,24 @@ $ make
 repo-template Makefile
 Usage: make [COMMAND]
 
-  help                 Shows all targets and help from the Makefile (this message).
+  help                      Print all Makefile targets (this message).
 Tools
-  license-headers      Update license headers.
+  license-headers           Update license headers.
 Formatting
-  format               Format all files
-  md-format            Format Markdown files.
-  yaml-format          Format YAML files.
+  format                    Format all files
+  json-format               Format JSON files.
+  md-format                 Format Markdown files.
+  yaml-format               Format YAML files.
 Linting
-  lint                 Run all linters.
-  actionlint           Runs the actionlint linter.
-  zizmor               Runs the zizmor linter.
-  markdownlint         Runs the markdownlint linter.
-  textlint             Runs the textlint linter.
-  yamllint             Runs the yamllint linter.
+  lint                      Run all linters.
+  actionlint                Runs the actionlint linter.
+  zizmor                    Runs the zizmor linter.
+  markdownlint              Runs the markdownlint linter.
+  renovate-config-validator Validate Renovate configuration.
+  textlint                  Runs the textlint linter.
+  yamllint                  Runs the yamllint linter.
 Maintenance
-  clean                Delete temporary files.
+  clean                     Delete temporary files.
 ```
 
 ### Formatting and linting


### PR DESCRIPTION
**Description:**

Don't output color in `Makefile` help to non-terminals.

**Related Issues:**

Fixes #178

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
