### PR TITLE
fix: set textlint exit_code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ textlint: node_modules/.installed $(AQUA_ROOT_DIR)/.installed ## Runs the textli
 					line=$$(echo "$$m" | jq -c -r '.loc.start.line'); \
 					endline=$$(echo "$$m" | jq -c -r '.loc.end.line'); \
 					message=$$(echo "$$m" | jq -c -r '.message'); \
+					exit_code=1; \
 					echo "::error file=$${file},line=$${line},endLine=$${endline}::$${message}"; \
 				done <<<"$$(echo "$$p" | jq -c -r '.messages[] // empty')"; \
 			done <<< "$$(./node_modules/.bin/textlint -c .textlintrc.yaml --format json $${files} 2>&1 | jq -c '.[]')"; \


### PR DESCRIPTION
**Description:**

Set the `exit_code` for the `textlint` `Makefile` target.

**Related Issues:**

Fixes #200 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
