### PR TITLE
chore: Set unordered lint indentation to 4

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -18,7 +18,7 @@ MD004:
 
 # MD007/ul-indent - Unordered list indentation
 MD007:
-  indent: 2
+  indent: 4
 
 # MD013/line-length - Line length
 MD013: false


### PR DESCRIPTION
**Description:**

Set markdown unordered lint indentation to 4 to be consistent with prettier.

**Related Issues:**

Fixes #217 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
