### PR TITLE
chore: Use `customManagers:makefileVersions`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,13 @@ OUTPUT_FORMAT ?= $(shell if [ "${GITHUB_ACTIONS}" == "true" ]; then echo "github
 REPO_ROOT = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 REPO_NAME = $(shell basename "$(REPO_ROOT)")
 
-AQUA_VERSION ?= 2.51.2
+# renovate: datasource=github-releases depName=aquaproj/aqua versioning=loose
+AQUA_VERSION ?= v2.51.2
 AQUA_REPO ?= github.com/aquaproj/aqua
 AQUA_CHECKSUM.Linux.x86_64 = 17db2da427bde293b1942e3220675ef796a67f1207daf89e6e80fea8d2bb8c22
 AQUA_CHECKSUM.Linux.aarch64 = b3f0d573e762ce9d104c671b8224506c4c4a32eedd1e6d7ae1e1e39983cdb6a8
 AQUA_CHECKSUM ?= $(AQUA_CHECKSUM.$(uname_s).$(uname_m))
-AQUA_URL = https://$(AQUA_REPO)/releases/download/v$(AQUA_VERSION)/aqua_$(kernel)_$(arch).tar.gz
+AQUA_URL = https://$(AQUA_REPO)/releases/download/$(AQUA_VERSION)/aqua_$(kernel)_$(arch).tar.gz
 AQUA_ROOT_DIR = $(REPO_ROOT)/.aqua
 
 # The help command prints targets in groups. Help documentation in the Makefile
@@ -90,7 +91,7 @@ node_modules/.installed: package-lock.json
 .bin/aqua-$(AQUA_VERSION)/aqua:
 	@set -euo pipefail; \
 		mkdir -p .bin/aqua-$(AQUA_VERSION); \
-		tempfile=$$(mktemp --suffix=".aqua-v$(AQUA_VERSION).tar.gz"); \
+		tempfile=$$(mktemp --suffix=".aqua-$(AQUA_VERSION).tar.gz"); \
 		curl -sSLo "$${tempfile}" "$(AQUA_URL)"; \
 		echo "$(AQUA_CHECKSUM)  $${tempfile}" | sha256sum -c; \
 		tar -x -C .bin/aqua-$(AQUA_VERSION) -f "$${tempfile}"

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,10 @@
     // Add Aqua present to allow updating CLI tools.
     // https://aquaproj.github.io/docs/guides/renovate/
     "github>aquaproj/aqua-renovate-config#2.7.5",
+
+    // Update version numbers in Makefile.
+    // https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions
+    "customManagers:makefileVersions",
   ],
 
   // Security alerts/updates happen more frequently.
@@ -25,17 +29,6 @@
   // an existing issue which can be very old and is easily missed. Opening new
   // issues is more intuitive.
   configWarningReuseIssue: false,
-
-  // Update the Aqua version set in the Makefile.
-  customManagers: [
-    {
-      customType: "regex",
-      managerFilePatterns: ["/Makefile/"],
-      matchStrings: ["AQUA_VERSION \\??= *(?<currentValue>\\S+)"],
-      depNameTemplate: "aquaproj/aqua",
-      datasourceTemplate: "github-releases",
-    },
-  ],
 
   // Group various ecosystem updates. Security updates are always separate.
   packageRules: [


### PR DESCRIPTION
**Description:**

Use [`customManagers:makefileVersions`](https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions) to manage the Aqua version.

**Related Issues:**

Fixes #223 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
