### PR TITLE
fix: Use --package-lock-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ help: ## Print all Makefile targets (this message).
 				}'
 
 package-lock.json: package.json
-	@npm install
-	@npm audit signatures
+	@npm install --package-lock-only --no-audit --no-fund --no-save
 
 node_modules/.installed: package-lock.json
 	@npm clean-install


### PR DESCRIPTION
**Description:**

Add `--package-lock-only --no-audit --no-fund --no-save` to `npm install` so that it only updates the `package-lock.json` file.

**Related Issues:**

Fixes #251 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
