### PR TITLE
fix: Use set -euo pipefail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ renovate-config-validator: node_modules/.installed ## Validate Renovate configur
 
 .PHONY: textlint
 textlint: node_modules/.installed $(AQUA_ROOT_DIR)/.installed ## Runs the textlint linter.
-	@set -e;\
+	@set -euo pipefail;\
 		files=$$( \
 			git ls-files --deduplicate \
 				'*.md' \


### PR DESCRIPTION
**Description:**

Set `-euo pipefail` for the `textlint` make target.

**Related Issues:**

Fixes #249 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
