### PR TITLE
fix: pass --config to zizmor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,7 @@ zizmor: .venv/.installed ## Runs the zizmor linter.
 		fi; \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			.venv/bin/zizmor \
+				--config .zizmor.yml \
 				--quiet \
 				--pedantic \
 				--format sarif \


### PR DESCRIPTION
**Description:**

Set the `--config` flag for `zizmor` when generating sarif output.

**Related Issues:**

Fixes #263

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
