### PR TITLE
chore: use  for file creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ package-lock.json: package.json
 node_modules/.installed: package-lock.json
 	@npm clean-install
 	@npm audit signatures
-	@touch node_modules/.installed
+	@touch $@
 
 .venv/bin/activate:
 	@python -m venv .venv


### PR DESCRIPTION
**Description:**

Use `touch $@` reference for file creation in `make` target.

**Related Issues:**

Fixes #262

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
