### PR TITLE
chore: set prHourlyLimit

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,10 @@
     // https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions
     "customManagers:makefileVersions",
   ],
+  // NOTE: Set the prHourlyLimit to 0 to disable the hourly limit. This is done
+  // because we are using a monthly schedule and the default hourly limit of 2
+  // would cause Renovate to only create 2 PRs every month.
+  prHourlyLimit: 0,
 
   // Security alerts/updates happen more frequently.
   vulnerabilityAlerts: {


### PR DESCRIPTION
**Description:**

Set the `prHourlyLimit` to zero to allow renovate to create all necessary PRs every month.

**Related Issues:**

Fixes #274

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
