### PR TITLE
chore: enable lockFileMaintenance for renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -31,6 +31,12 @@
   },
   osvVulnerabilityAlerts: true,
 
+  // Enable the lock file maintenance feature to keep transitive dependencies up
+  // to date.
+  lockFileMaintenance: {
+    enabled: true,
+  },
+
   // Create a new issue for each config warning. By default, Renovate re-opens
   // an existing issue which can be very old and is easily missed. Opening new
   // issues is more intuitive.


### PR DESCRIPTION
**Description:**

Enable the `lockFileMaintenance` feature for renovate to keep transitive dependencies up to date.

**Related Issues:**

Fixes #283

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
