### PR TITLE
ci: create local branches in commitlint workflow

### DIFF
--- a/.github/workflows/workflow_call.commitlint.yml
+++ b/.github/workflows/workflow_call.commitlint.yml
@@ -41,6 +41,17 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".node-version"
+      # NOTE: actions/checkout does not set up local branches
+      - run: |
+          set -euo pipefail
+          current_branch=$(git rev-parse --abbrev-ref HEAD)
+          for remote_branch in $(git branch -r | grep -v "\->" | grep -v -e "^\s*pull/"); do
+            local_branch=$(echo "${remote_branch}" | sed 's/origin\///')
+            if [[ "${local_branch}" == "${current_branch}" ]]; then
+              continue
+            fi
+            git branch --track "${local_branch}" "${remote_branch}"
+          done
       - env:
           COMMITLINT_FROM_REF: ${{ inputs.from_ref }}
           COMMITLINT_TO_REF: ${{ inputs.to_ref }}

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,13 @@ commitlint: node_modules/.installed ## Run commitlint linter.
 			commitlint_from=$$(git remote show origin | grep 'HEAD branch' | awk '{print $$NF}'); \
 		fi; \
 		if [ "$${commitlint_to}" == "" ]; then \
-			commitlint_to=HEAD; \
+			# if head is on the commitlint_from branch, then we will lint the \
+			# last commit by default. \
+			current_branch=$$(git rev-parse --abbrev-ref HEAD); \
+			if [ "$${commitlint_from}" == "$${current_branch}" ]; then \
+				commintlint_from="HEAD~1"; \
+			fi; \
+			commitlint_to="HEAD"; \
 		fi; \
 		./node_modules/.bin/commitlint \
 			--config commitlint.config.mjs \


### PR DESCRIPTION
**Description:**

Create local branches in `commitlint` workflow. GitHub Actions does not create local tracking branches even when `fetch-depth: 0` so they must be created manually. This is so that we can use them as from and to ref with `commitlint`.

**Related Issues:**

Fixes #304

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
