### PR TITLE
ci(fix): Use --no-error-on-unmatched-pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ json-format: node_modules/.installed ## Format JSON files.
 			exit 0; \
 		fi; \
 		./node_modules/.bin/prettier \
+			--no-error-on-unmatched-pattern \
 			--write \
 			$${files}
 
@@ -177,6 +178,7 @@ md-format: node_modules/.installed ## Format Markdown files.
 		fi; \
 		# NOTE: prettier uses .editorconfig for tab-width. \
 		./node_modules/.bin/prettier \
+			--no-error-on-unmatched-pattern \
 			--write \
 			$${files}
 
@@ -192,6 +194,7 @@ yaml-format: node_modules/.installed ## Format YAML files.
 			exit 0; \
 		fi; \
 		./node_modules/.bin/prettier \
+			--no-error-on-unmatched-pattern \
 			--write \
 			$${files}
 


### PR DESCRIPTION
**Description:**

Use `--no-error-on-unmatched-pattern` with prettier to avoid errors when specified files are symlinks.

**Related Issues:**

Fixes #302

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
