### PR TITLE
chore(ci): set GH_TOKEN for markdownlint workflow

### DIFF
--- a/.github/workflows/workflow_call.markdownlint.yml
+++ b/.github/workflows/workflow_call.markdownlint.yml
@@ -31,4 +31,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".node-version"
-      - run: make markdownlint
+      - name: markdownlint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make markdownlint


### PR DESCRIPTION
**Description:**

Set the `GH_TOKEN` for the `markdownlint` workflow so that GitHub API requests are authenticated.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
