### PR TITLE
ci(fix): set GitHub token for textlint workflow

### DIFF
--- a/.github/workflows/workflow_call.textlint.yml
+++ b/.github/workflows/workflow_call.textlint.yml
@@ -31,4 +31,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".node-version"
-      - run: make textlint
+      - name: textlint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make textlint


### PR DESCRIPTION
**Description:**

Set the GitHub token for the `textlint` workflow to avoid rate limiting errors.

**Related Issues:**

Updates #322 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
