### PR TITLE
fix: commitlint from ref typo bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ commitlint: node_modules/.installed ## Run commitlint linter.
 		# last commit by default. \
 		current_branch=$$(git rev-parse --abbrev-ref HEAD); \
 		if [ "$${commitlint_from}" == "$${current_branch}" ]; then \
-			commintlint_from="HEAD~1"; \
+			commitlint_from="HEAD~1"; \
 		fi; \
 		commitlint_to="HEAD"; \
 	fi; \


### PR DESCRIPTION
**Description:**

Fix setting the `commitlint` from ref when running on the main branch.

**Related Issues:**

Fixes #331 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
