### PR TITLE
chore(ci): fetch the HEAD ref for default branch

### DIFF
--- a/.github/workflows/workflow_call.commitlint.yml
+++ b/.github/workflows/workflow_call.commitlint.yml
@@ -45,6 +45,11 @@ jobs:
 
       # NOTE: actions/checkout does not set up local branches
       - run: |
+          # Fetch the HEAD ref. This is necessary to get the correct default
+          # branch.
+          git remote set-head origin --auto
+
+          # Create local branches for all remote branches except pull requests.
           set -euo pipefail
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           for remote_branch in $(git branch -r | grep -v "\->" | grep -v -e "^\s*pull/"); do


### PR DESCRIPTION
**Description:**

Fetch the remote `HEAD` branch for `origin`. This gets the default branch so it can be used in `make commitlint`. This is typically available with a normal `git` checkout but `actions/checkout` does not create this ref.

**Related Issues:**

Fixes #357 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
