### PR TITLE
chore: set prConcurrentLimit to zero

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,9 @@
   // NOTE: Set the prHourlyLimit to 0 to disable the hourly limit. This is done
   // because we are using a monthly schedule and the default hourly limit of 2
   // would cause Renovate to only create 2 PRs every month.
+  // Similarly set prConcurrentLimit to 0 to disable the concurrent PR limit.
   prHourlyLimit: 0,
+  prConcurrentLimit: 0,
 
   // Security alerts/updates.
   vulnerabilityAlerts: {


### PR DESCRIPTION
**Description:**

Set `prConcurrentLimit` to zero so that monthly PRs are not rate limited.

**Related Issues:**

Fixes #367 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
