### PR TITLE
feat: partial Darwin ARM64 support

### DIFF
--- a/.textlintrc.yaml
+++ b/.textlintrc.yaml
@@ -21,6 +21,8 @@ rules:
   spelling:
     language: "en"
     skipPatterns:
+      - "/\\bAMD64\\b/g"
+      - "/\\bARM64\\b/g"
       - "/\\bCHANGELOG\\b/g"
       - "/\\bCODEOWNER\\b/g"
       - "/\\bCLA\\b/g"
@@ -34,12 +36,13 @@ rules:
       - "/\\bCodeQL\\b/g"
       - "/\\bDependabot\\b/g"
       - "/\\bJavaScript\\b/g"
-      - "/\\bMacOS\\b/g"
       - "/\\bMakefile\\b/g"
       - "/\\bNode.js\\b/g"
       - "/\\bOpenSSF\\b/g"
       - "/\\bTODOs?\\b/g"
       - "/\\be2e\\b/g"
+      - "/\\bmacOS\\b/g"
+      - "/\\bx86-64\\b/g"
       - "/\\b[Ff]ormatters?\\b/g"
       - "/\\b[Ll]inters?\\b/g"
       - "/\\b[Pp]ositivity\\b/g"

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ for more recommended security settings.
 
 ## Requirements
 
-This repository template is meant to be used on Linux systems. It may still
-work on MacOS or Windows given a `bash` environment, but this is not tested.
+This repository template is meant to be used on Linux x86-64 (AMD64) systems.
+There is partial support for macOS ARM64 but `checkmake` does not provide an
+ARM64 release binary so it doesn't work on macOS.
 
 In general, dependencies on outside tools should be minimized in favor of
 including them as project-local dependencies.


### PR DESCRIPTION
**Description:**

Adds partial Darwin ARM64 support. `checkmake` does not provide ARM64 binaries for Darwin so it doesn't work currently.

**Related Issues:**

Updates #377 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
