### PR TITLE
fix: don't run `autogen.sh` on TOML files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,6 @@ license-headers: ## Update license headers.
 			'*.py' \
 			'*.rb' \
 			'*.rs' \
-			'*.toml' \
 			'*.yaml' \
 			'*.yml' \
 			'Makefile' \


### PR DESCRIPTION
**Description:**

`autogen.sh` doesn't support TOML files. They should be ignored from
the `license-headers` target because it generates an error if any TOML
files are located in the repository.

**Related Issues:**

Fixes #398 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
