### PR TITLE
feat: ignore "Initial plan" commits by Copilot

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -14,4 +14,9 @@
 
 export default {
   extends: ["@commitlint/config-conventional"],
+
+  ignores: [
+    // Ignore the Initial plan commits created by the GitHub Copilot agent.
+    (commit) => /^[Ii]nitial plan/.test(commit),
+  ],
 };


### PR DESCRIPTION
**Description:**

Copilot creates "Initial plan" commits that don't conform to conventional commits and cannot be influenced by prompts or `AGENTS.md`. Update `commitlint` config to ignore these commits.

**Related Issues:**

Fixes #400 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
