### PR TITLE
fix: small issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ node_modules/.installed: package-lock.json
 	mkdir -p .bin/aqua-$(AQUA_VERSION); \
 	tempfile=$$($(MKTEMP) --suffix=".aqua-$(AQUA_VERSION).tar.gz"); \
 	curl -sSLo "$${tempfile}" "$(AQUA_URL)"; \
-	echo "$(AQUA_CHECKSUM)  $${tempfile}" | sha256sum -c -; \
+	echo "$(AQUA_CHECKSUM)  $${tempfile}" | shasum -a 256 -c -; \
 	tar -x -C .bin/aqua-$(AQUA_VERSION) -f "$${tempfile}"
 
 $(AQUA_ROOT_DIR)/.installed: .aqua.yaml .bin/aqua-$(AQUA_VERSION)/aqua
@@ -230,6 +230,7 @@ license-headers: ## Update license headers.
 		>&2 echo "git user.name is required."; \
 		>&2 echo "Set it up using:"; \
 		>&2 echo "git config user.name \"John Doe\""; \
+		exit 1; \
 	fi; \
 	for filename in $${files}; do \
 		if ! ( head "$${filename}" | $(GREP) -iL "Copyright" > /dev/null ); then \


### PR DESCRIPTION
**Description:**

- Add `exit` after error message in `license-headers`
- Use `shasum` instead of `sha256sum` for compatibility.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
