### PR TITLE
chore(ci): add event name to concurrency group

### DIFF
--- a/.github/workflows/schedule.issue-reopener.yml
+++ b/.github/workflows/schedule.issue-reopener.yml
@@ -30,7 +30,9 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # NOTE: Allow runs to execute sequentially. This prevents a push event from
+  #       canceling an issues event run when a merge to main closes an issue.
+  cancel-in-progress: false
 
 jobs:
   issue-reopener:


### PR DESCRIPTION
**Description:**

Allow `todo-issue-reopener` workflow runs to execute sequentially. This
prevents a push event from canceling an issues event run when a merge to
main closes an issue.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
