### PR TITLE
fix: return correct exit code on GHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,16 +449,16 @@ textlint: node_modules/.installed $(AQUA_ROOT_DIR)/.installed ## Runs the textli
 		while IFS="" read -r p && [ -n "$$p" ]; do \
 			filePath=$$(echo "$$p" | jq -cr '.filePath // empty'); \
 			file=$$(realpath --relative-to="." "$${filePath}"); \
-			messages=$$(echo "$$p" | jq -cr '.messages[] // empty'); \
 			while IFS="" read -r m && [ -n "$$m" ]; do \
 				line=$$(echo "$$m" | jq -cr '.loc.start.line // empty'); \
 				endline=$$(echo "$$m" | jq -cr '.loc.end.line // empty'); \
 				col=$$(echo "$${m}" | jq -cr '.loc.start.column // empty'); \
 				endcol=$$(echo "$${m}" | jq -cr '.loc.end.column // empty'); \
 				message=$$(echo "$$m" | jq -cr '.message // empty'); \
+				exit_code=1; \
 				echo "::error file=$${file},line=$${line},endLine=$${endline},col=$${col},endColumn=$${endcol}::$${message}"; \
-			done <<<"$${messages}"; \
-		done <<<"$${textlint_out}"; \
+			done <<<"$$(echo "$${p}" | jq -cr '.messages[] // empty')"; \
+		done <<<"$$($(REPO_ROOT)/node_modules/.bin/textlint --format json $${files} 2>&1 | jq -c '.[]')"; \
 		exit "$${exit_code}"; \
 	else \
 		$(REPO_ROOT)/node_modules/.bin/textlint \


### PR DESCRIPTION
**Description:**

Return the correct exit code when running `textlint` on GitHub Actions.

**Related Issues:**

Fixes #437 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
