### PR TITLE
ci(fix): git credentials error

### DIFF
--- a/.github/workflows/workflow_call.commitlint.yml
+++ b/.github/workflows/workflow_call.commitlint.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true # required for `git remote set-head`
           fetch-depth: 0 # Fetch all history for all branches and tags
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0


### PR DESCRIPTION
**Description:**

Maintain git credentials in the `commitlint` workflow so that `git remote set-head` will work for private repositories.

**Related Issues:**

Fixes #433

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
