### PR TITLE
chore(commitlint): add scope-empty to config

### DIFF
--- a/.textlintrc.yaml
+++ b/.textlintrc.yaml
@@ -46,6 +46,7 @@ rules:
       - "/\\bmacOS\\b/g"
       - "/\\bx86-64\\b/g"
       - "/\\b[Cc]hecksums?\\b/g"
+      - "/\\b[Cc]odebases?\\b/g"
       - "/\\b[Ff]ormatters?\\b/g"
       - "/\\b[Ll]inters?\\b/g"
       - "/\\b[Ll]ockfiles?\\b/g"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 

--- a/README.md
+++ b/README.md
@@ -343,11 +343,20 @@ Commits](https://www.conventionalcommits.org/en/v1.0.0/) to standardize commit
 message formatting. Conventional commits can help to communicate the nature of
 changes at a glance, and give hints on backwards compatibility.
 
-While you _may_ use conventional commits to automatically determine the next
-release version, it is **not** recommended to use conventional commits to auto
-generate user-facing documentation such as the `CHANGELOG.md` or release notes.
-These should be written for an end-user audience, be human readable, and include
-additional relevant information and context.
+While you _may_ use conventional commits to automate releases, it is **not**
+recommended to use commit messages to automatically determine the next
+release version, or to auto-generate user-facing documentation such as the
+`CHANGELOG.md` or release notes. These should be written for an end-user
+audience, be human readable, and include additional relevant information and
+context.
+
+This repository deviates slightly from the conventional commits specification by
+requiring that all commits include a scope. Scope is project specific and could
+refer to a component, module, or section of the codebase.
+
+This post explains some of the rationale:
+
+- [Stop Using Conventional Commits](https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/) - _Sumner Evans_
 
 ## Keeping repositories in sync
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -15,8 +15,19 @@
 export default {
   extends: ["@commitlint/config-conventional"],
 
+  rules: {
+    // Enforce including a scope in the commit message. This is normally
+    // optional in the conventional commit specification, but we want to require
+    // it for better commit message clarity.
+    // https://sumnerevans.com/posts/software-engineering/stop-using-conventional-commits/
+    "scope-empty": [2, "never"],
+  },
+
   ignores: [
-    // Ignore the Initial plan commits created by the GitHub Copilot agent.
+    // Ignore the 'Initial plan' commits created by the GitHub Copilot agent.
+    // Currently the agent ignores any repository instructions when creating
+    // this commit and so it can't be changed.
+    // https://github.com/orgs/community/discussions/178992
     (commit) => /^[Ii]nitial plan/.test(commit),
   ],
 };


### PR DESCRIPTION
**Description:**

Add `scope-empty` to the `commitlint` config to require that the commit message includes a scope. This is normally optional in conventional commits.

**Related Issues:**

- #473 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
