### PR TITLE
docs(README): add web-based signoff to checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,17 @@ repository template.
        to preserve the original commit history of a pull request. This makes it
        easier to retain the original commit messages and signatures of
        contributors. Disallowing squash merges and rebase merges is recommended.
+2. [ ] **Require contributors to sign off on web-based commits**: This is
+       recommended to ensure that all commits made through the GitHub web
+       interface are signed off by the author with a Developer Certificate of
+       Origin (DCO).
 
 #### GitHub Apps
 
 1. [ ] **Enable [DCO](https://github.com/apps/dco):** Enable the DCO GitHub App
-       to ensure that all commits are signed off by the author. This is a
-       lightweight alternative to a [Contributor License
-       Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement)
+       to ensure that all commits are signed off by the author with a DCO. This
+       is a lightweight alternative to a
+       [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement)
        (CLA) for contributors to certify that they wrote or otherwise have the
        right to submit the code they are contributing to the project. If you
        have a CLA you can omit this step.


### PR DESCRIPTION
**Description:**

Add the "Require contributors to sign off on web-based commits" setting to the repository creation checklist.

**Related Issues:**

- #444 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
