### PR TITLE
fix(makefile): add --locked flag to uv sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ uv.lock: pyproject.toml .uv/.installed
 
 .venv/.installed: pyproject.toml .uv/.installed
 	@# bash \
-	$(REPO_ROOT)/.uv/venv/bin/uv sync; \
+	$(REPO_ROOT)/.uv/venv/bin/uv sync --locked; \
 	touch $@
 
 # Aqua setup


### PR DESCRIPTION
**Description:**

Add `--locked` to `uv sync` so that the `uv.lock` is not updated.

**Related Issues:**

- #486 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
