### PR TITLE
fix(renovate): reset prCreation to default

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,11 +38,13 @@
   // Apply a dependency cooldown of 14 days. This helps to avoid issues with
   // compromised releases.
   // https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+  // https://docs.renovatebot.com/configuration-options/#minimumreleaseage
   minimumReleaseAge: "14 days",
-  // These options suppress PR creation for dependencies that were released
-  // within minimumReleaseAge.
-  // https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days
-  prCreation: "not-pending",
+  // internalChecksFilter suppress PR creation for dependencies that were
+  // released within minimumReleaseAge.
+  // strict: All pending releases will be filtered. PRs will be skipped unless a
+  // non-pending version is available.
+  // https://docs.renovatebot.com/configuration-options/#internalchecksfilter
   internalChecksFilter: "strict",
 
   // Enable the lock file maintenance feature to keep transitive dependencies up


### PR DESCRIPTION
**Description:**

Revert `prCreation` option to the default to allow PRs to be created rather than stuck in pending state.

**Related Issues:**

- Resolves #496 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
