### PR TITLE
fix: correct evironment to environment typo in include.mk

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -39,7 +39,7 @@ DEBUG_LOGGING ?=
 # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 GITHUB_ACTIONS ?=
 
-# The RUNNER_DEBUG evironment variable is set to '1' when debug mode is enabled.
+# The RUNNER_DEBUG environment variable is set to '1' when debug mode is enabled.
 # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
 RUNNER_DEBUG ?=
 


### PR DESCRIPTION
Hi @ianlewis 👋

Just a small typo fix — 'evironment' → 'environment' in the comment on line 42 of `include.mk`.

Happy to address any feedback!