### PR TITLE
fix(makefile): ignore inBundle==true in integrity check

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -162,8 +162,8 @@ $(REPO_ROOT)/package-lock.json: $(REPO_ROOT)/package.json $(AQUA_ROOT_DIR)/.inst
 	nointegrity=""
 	noresolved=""
 	if [ -f "$@" ]; then
-		nointegrity=$$(jq '.packages | del(."") | .[] | select(has("integrity") | not)' < $@)
-		noresolved=$$(jq '.packages | del(."") | .[] | select(has("resolved") | not)' < $@)
+		nointegrity=$$(jq '.packages | del(."") | .[] | select(.inBundle | not) | select(has("integrity") | not)' < $@)
+		noresolved=$$(jq '.packages | del(."") | .[] | select(.inBundle | not) | select(has("resolved") | not)' < $@)
 	fi
 	if [ ! -f "$@" ] || [ -n "$${nointegrity}" ] || [ -n "$${noresolved}" ]; then
 		# NOTE: package-lock.json is removed to ensure that npm includes the


### PR DESCRIPTION
**Description:**

Ignore packages with `inBundle==true` when checking for packages without an `integrity` hash.

**Related Issues:**

- Resolves #375 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
