### PR TITLE
fix(makefile): set default npm loglevel to notice

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -186,7 +186,7 @@ $(REPO_ROOT)/package-lock.json: $(REPO_ROOT)/package.json $(AQUA_ROOT_DIR)/.inst
 
 $(REPO_ROOT)/node_modules/.installed: $(REPO_ROOT)/package.json
 	@echo "Installing Node.js dependencies..."
-	loglevel="silent"
+	loglevel="notice"
 	if [ -n "$(DEBUG_LOGGING)" ]; then
 		loglevel="verbose"
 	fi


### PR DESCRIPTION
**Description:**

Set `npm --loglevel` default to `"notice"`.

**Related Issues:**

n/a

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
